### PR TITLE
Updating the resource to allow configuring the decay rate of the tank

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -115,7 +115,7 @@ local function startOxygenLevelDecrementerThread()
     CreateThread(function()
         while currentGear.enabled do
             if IsPedSwimmingUnderWater(cache.ped) and oxygenLevel > 0 then
-                oxygenLevel -= 1
+                oxygenLevel -= config.decayRate
                 if oxygenLevel % 10 == 0 and oxygenLevel ~= config.startingOxygenLevel then
                     -- Initiate breathing suit audio
                 end

--- a/config/client.lua
+++ b/config/client.lua
@@ -2,5 +2,6 @@ return {
     startingOxygenLevel = 100,
     putOnSuitTimeMs = 5000,
     takeOffSuitTimeMs = 5000,
-    refillTankTimeMs = 5000
+    refillTankTimeMs = 5000,
+    decayRate = 1, -- The rate at which the oxygen level decays. Defaults to 1.
 }


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Implements feature request: https://github.com/Qbox-project/qbx_divegear/issues/16 to allow for configuring the decay rate of the oxygen tank. This will allow people to let tanks last longer, if they choose to. 

The default setting is 1, and a comment is in the config to indicate this.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
